### PR TITLE
Giulio/fix setup readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ The feature selector returns 3 possible feature sets that can be inspected as:
 
 ```python
 min_feats = selected_features["min"]
-mid_feats = selected_features["min"]
-max_feats = selected_features["min"]
+mid_feats = selected_features["mid"]
+max_feats = selected_features["max"]
 ```
 
 - **`min_feats`**: The minimum number of features for which the model performs optimally.

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     include_package_data=True,
     keywords="omigami",
     name="omigami",
-    packages=find_packages(include=["omigami"]),
+    packages=find_packages(exclude=["tests"]),
     setup_requires=setup_requirements,
     test_suite="tests",
     tests_require=test_requirements,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 import versioneer
 from setuptools import setup, find_packages
 
-with open("README.md") as readme_file:
+with open("docs/readme.rst") as readme_file:
     readme = readme_file.read()
 
 with open("HISTORY.rst") as history_file:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 import versioneer
 from setuptools import setup, find_packages
 
-with open("README.rst") as readme_file:
+with open("README.md") as readme_file:
     readme = readme_file.read()
 
 with open("HISTORY.rst") as history_file:


### PR DESCRIPTION
The readme must be an RST. We already have one for the docs pointing to the Github page, so we can use that for now. Unfortunately, it seems impossible to embed a `.md`inside a `.rst`